### PR TITLE
feat: ability to specify ACL for files created on the S3 bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+/.idea/

--- a/lambda.js
+++ b/lambda.js
@@ -3,7 +3,7 @@ const s3 = new AWS.S3();
 const ylt = require('yellowlabtools');
 
 // noinspection JSUnusedLocalSymbols
-async function runner({id, url, options = {}}, context) {
+async function runner({id, url, options = {}, acl}, context) {
     console.log(`Processing run #${id} on ${url}`);
     
     // AWS S3 bucket and path
@@ -11,7 +11,7 @@ async function runner({id, url, options = {}}, context) {
     const keyPrefix = `results/${id}`;
 
     // Function that can save any file on S3 (JSON, screenshot,...)
-    const saveFile = async (path, content) => s3.putObject({Bucket: bucket, Key: `${keyPrefix}/${path}`, Body: content})
+    const saveFile = async (path, content, contentType = undefined) => s3.putObject({Bucket: bucket, Key: `${keyPrefix}/${path}`, Body: content, ...(!!contentType ? {ContentType: contentType} : {}), ...(!!acl ? {ACL: acl} : {})})
         .promise();
     
     // Let's launch ylt
@@ -21,7 +21,7 @@ async function runner({id, url, options = {}}, context) {
         console.log(`Run succeeded`);
 
         data.runId = id;
-        await saveFile('results.json', JSON.stringify(data));
+        await saveFile('results.json', JSON.stringify(data), 'application/json');
 
         return {
             status: 'processed',


### PR DESCRIPTION
This pull request provides ability to specify `ACL` (public-read / private) to use when creating the json results file on the S3 bucket. By default, the file is in `private` ACL mode, but if you want to store it on an s3 bucket that is directly accessed by a cloudfront distribution, it could be useful to enable public-read acl by providing `acl: "public-read"` as a value.

The second feature is the ability to specify the content-type when using the internal `saveFile()` helper function here. This is useful as well if you want to expose the file created on the s3 bucket directly to cloudfront that will read the content-type and re-send it as the response content-type.